### PR TITLE
Fix plugin execution on windows

### DIFF
--- a/src/main/java/com/github/bsideup/gradle/plugins/maven/sync/EffectiveModelBuilder.java
+++ b/src/main/java/com/github/bsideup/gradle/plugins/maven/sync/EffectiveModelBuilder.java
@@ -26,8 +26,12 @@ import java.util.stream.Stream;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toMap;
 
-public enum EffectiveModelBuilder implements Function<Project, Map<MavenCoordinates, Set<Consumer<Project>>>> {
-  INSTANCE;
+public class EffectiveModelBuilder implements Function<Project, Map<MavenCoordinates, Set<Consumer<Project>>>> {
+  public final String mavenBinaryName;
+
+  public EffectiveModelBuilder(String mavenBinaryName) {
+    this.mavenBinaryName = mavenBinaryName;
+  }
 
   @Override
   @SneakyThrows
@@ -42,7 +46,7 @@ public enum EffectiveModelBuilder implements Function<Project, Map<MavenCoordina
 
     try {
       // TODO Maven Wrapper support
-      new ProcessExecutor("mvn", "-q", "help:effective-pom", "-Doutput=" + tempFile.toAbsolutePath().toString())
+      new ProcessExecutor(mavenBinaryName, "-q", "help:effective-pom", "-Doutput=\"" + tempFile.toAbsolutePath().toString() + "\"")
           .directory(rootProject.getRootDir())
           .exitValueNormal()
           .readOutput(true)

--- a/src/main/java/com/github/bsideup/gradle/plugins/maven/sync/MavenDependenciesPlugin.java
+++ b/src/main/java/com/github/bsideup/gradle/plugins/maven/sync/MavenDependenciesPlugin.java
@@ -27,7 +27,14 @@ public class MavenDependenciesPlugin implements Plugin<Project> {
       return;
     }
 
-    val model = MODELS.computeIfAbsent(project.getRootProject(), EffectiveModelBuilder.INSTANCE);
+    String mavenBinaryName;
+    if(System.getProperty("os.name").toLowerCase().contains("windows")) {
+      mavenBinaryName = "mvn.cmd";
+    } else {
+      mavenBinaryName = "mvn";
+    }
+
+    val model = MODELS.computeIfAbsent(project.getRootProject(), new EffectiveModelBuilder(mavenBinaryName));
     for (val dependency : model.get(coordinates.get())) {
       dependency.accept(project);
     }


### PR DESCRIPTION
Firstly, thank you for this plugin.

This change fixes plugin execution on windows platforms for maven 3.3+
For some unknown reason windows platform not recognize call to mvn from ProcessExecutor, only 'mvn.bat' or 'mvn.cmd' works. 
As mvn.bat is pre 3.3+ idiom i've taken liberty and put 'mvn.cmd' as required binary for launch. 

Please let me know if i can/should fix anything else.